### PR TITLE
fix merged (antisplit) apk signing on release builds

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -24,5 +24,6 @@
 -keep class org.eclipse.tm4e.** { *; }
 -keep class org.joni.** { *; }
 -keep class android.content.** { *; }
+-keep class com.android.apksig.** { *; }
 
 -keepnames interface * { *; }


### PR DESCRIPTION
First off, I’m really sorry about this. I should’ve tested this on release builds when I did the feature PR. Because of this, I’m not sure how many releases went out with this bug unnoticed. We only tested this on debug builds where the issue doesn’t occur, as in debug builds ProGuard isn’t applied to classes, and they remain intact. However, in release builds, ProGuard interferes and performs some strange optimizations on the `apksig` library, which causes issues with any actions involving the library, like APK signing or verification. I realized this yesterday while working on another project and it hit me that we aren’t excluding this in File Explorer Compose (or Prism now xD), so here I am.

To reproduce this, try converting any split APK files to a single APK with signing enabled. You’ll notice the output file isn’t properly signed, and neither our app nor other apps like MT recognize it as a valid APK file.

Lastly, the new UI and animations are fantastic! I absolutely love them. They've even inspired some design ideas for my project. Truly amazing work!